### PR TITLE
Add Flask application and sample routes

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,16 @@
+from flask import Flask
+
+from .routes import openai_bp, astra_bp
+
+
+def create_app() -> Flask:
+    """Application factory for creating the Flask app."""
+    app = Flask(__name__)
+    app.register_blueprint(openai_bp)
+    app.register_blueprint(astra_bp)
+    return app
+
+
+# Create a default app for simple use cases
+app = create_app()
+

--- a/app/astra_utils.py
+++ b/app/astra_utils.py
@@ -1,0 +1,8 @@
+"""Utility functions for Astra database operations."""
+
+
+def update_record(data: dict) -> dict:
+    """Return a placeholder update response."""
+    # Placeholder update logic
+    return {"status": "updated", "data": data}
+

--- a/app/openai_utils.py
+++ b/app/openai_utils.py
@@ -1,0 +1,10 @@
+"""Utility functions for OpenAI operations."""
+
+
+def summarize(text: str) -> str:
+    """Return a short summary placeholder for the given text."""
+    if not text:
+        return ""
+    # Placeholder summarization logic
+    return text[:100]
+

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,23 @@
+from flask import Blueprint, jsonify, request
+
+from .openai_utils import summarize
+from .astra_utils import update_record
+
+openai_bp = Blueprint('openai', __name__, url_prefix='/openai')
+astra_bp = Blueprint('astra', __name__, url_prefix='/astra')
+
+
+@openai_bp.route('/summarize', methods=['POST'])
+def openai_summarize():
+    data = request.get_json(silent=True) or {}
+    text = data.get('text', '')
+    summary = summarize(text)
+    return jsonify({'summary': summary})
+
+
+@astra_bp.route('/update', methods=['POST'])
+def astra_update():
+    data = request.get_json(silent=True) or {}
+    result = update_record(data)
+    return jsonify(result)
+

--- a/run.py
+++ b/run.py
@@ -1,0 +1,5 @@
+from app import app
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)
+


### PR DESCRIPTION
## Summary
- add simple placeholder utilities for OpenAI and Astra
- create Flask app with blueprint registration
- implement sample endpoints `/openai/summarize` and `/astra/update`
- provide `run.py` to launch the app

## Testing
- `python -m py_compile app/*.py run.py`

------
https://chatgpt.com/codex/tasks/task_e_6868dd8b2a4c8325b6195a41554f8a87