### PR TITLE
Remove SimPy dependency from simulation

### DIFF
--- a/app/simulation_utils.py
+++ b/app/simulation_utils.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 from typing import Any
-import simpy
-import pandas as pd
 
 from sim import Portfolio, parseYAML
 
@@ -32,13 +30,12 @@ def run_simulation(events: Any | None = None, *, steps: int = 12) -> dict:
             events = []
     events = events or []
 
-    env = simpy.Environment()
-    portfolio = Portfolio(env)
+    portfolio = Portfolio()
 
     if events:
         portfolio.set_portfolio(events)
 
-    portfolio.run(until=steps)
+    portfolio.run(steps)
 
     return {
         "projects": portfolio.list_projects().to_dict(orient="records"),

--- a/sim/models.py
+++ b/sim/models.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pandas as pd
-import simpy
 
 from .constants import NIRATE, NITHRESHOLD, EMPLOYERPENSIONRATE, PENSIONFTETHRESHOLD
 from .utils import get_current_month, printtimestamp
@@ -74,8 +73,8 @@ class Worker:
 class ConsolidatedAccount:
     """Manages financial transactions for the portfolio."""
 
-    def __init__(self, env: simpy.Environment):
-        self.env = env
+    def __init__(self, portfolio=None):
+        self.portfolio = portfolio
         self.total_capital = 0
         self.total_payments = 0
         self.total_income = 0
@@ -91,7 +90,8 @@ class ConsolidatedAccount:
             self.total_income += transaction["amount"]
             transaction["amount"] = -transaction["amount"]
         self.balance = self.total_income - self.total_payments
-        transaction["date"] = self.env.now
+        date = self.portfolio.now if self.portfolio is not None else 0
+        transaction["date"] = date
         transaction["balance"] = self.balance
         self.register.append(transaction)
 

--- a/sim/utils.py
+++ b/sim/utils.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import yaml
 import pandas as pd
-import simpy
 from uuid import uuid4
 import ast
 
@@ -19,10 +18,14 @@ def get_current_month(start_month: str = "apr", month: int = 0) -> str:
     return ALL_MONTHS[current_month_index]
 
 
-def printtimestamp(env: simpy.Environment):
-    """Print a formatted timestamp for the simulation environment."""
-    month = get_current_month("apr", env.now - 1)
-    print(f"\nMonth: {env.now} ({month})")
+def printtimestamp(env_or_step):
+    """Print a formatted timestamp given a simulation step."""
+    if hasattr(env_or_step, "now"):
+        step = env_or_step.now
+    else:
+        step = int(env_or_step)
+    month = get_current_month("apr", step - 1)
+    print(f"\nMonth: {step} ({month})")
 
 
 def pivotbudget(db: pd.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- refactor `run_simulation` to create a `Portfolio` without SimPy
- convert `Portfolio` to a loop-based engine storing pending events
- rewrite `Project` to use a `step` method rather than a generator
- simplify `ConsolidatedAccount` to use portfolio time tracking
- update `printtimestamp` helper for new step-based API

## Testing
- `pytest -q` *(fails: FileNotFoundError for `Support.yaml`)*

------
https://chatgpt.com/codex/tasks/task_e_686d3e8a12088325a303f425c68beb91