### PR TITLE
Fix CodeMirror init

### DIFF
--- a/templates/partials/index_scripts.html
+++ b/templates/partials/index_scripts.html
@@ -199,12 +199,6 @@
                   });
                   editors[id] = view;
 
-                  // On file load (already in your updateFileInfo)
-                  if (editors[input.id]) {
-                      editors[input.id].dispatch({
-                          changes: { from: 0, to: editors[input.id].state.doc.length, insert: content }
-                      });
-                  }
               });
 
               // Download buttons


### PR DESCRIPTION
## Summary
- ensure CodeMirror editors attach correctly by removing invalid code referencing undefined variables

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: FileNotFoundError: Support.yaml)*

------
https://chatgpt.com/codex/tasks/task_e_686e9f3df6fc83259a006915dadab402