### PR TITLE
Fix CodeMirror initialization

### DIFF
--- a/templates/partials/index_scripts.html
+++ b/templates/partials/index_scripts.html
@@ -144,8 +144,7 @@
               });
           });
 
-          // Restore persisted files on load and initialise CodeMirror
-          document.addEventListener('DOMContentLoaded', () => {
+          function initializeEditors() {
               console.log("Loading saved files from localStorage");
               const ids = ['yaml_file', 'fcrdata_file', 'supportdata_file'];
               const keywords = ['item','description','type','budget','step','amount','date','term','projects','transactions','support'];
@@ -199,12 +198,6 @@
                   });
                   editors[id] = view;
 
-                  // On file load (already in your updateFileInfo)
-                  if (editors[input.id]) {
-                      editors[input.id].dispatch({
-                          changes: { from: 0, to: editors[input.id].state.doc.length, insert: content }
-                      });
-                  }
               });
 
               // Download buttons
@@ -224,7 +217,14 @@
                       }
                   });
               });
-          });
+          }
+
+          // Restore persisted files on load and initialise CodeMirror
+          if (document.readyState === 'loading') {
+              document.addEventListener('DOMContentLoaded', initializeEditors);
+          } else {
+              initializeEditors();
+          }
 
           function updateFileInfo(input, info) {
               if (input.files.length > 0) {


### PR DESCRIPTION
## Summary
- run CodeMirror setup immediately when DOM is already loaded

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: FileNotFoundError: Support.yaml)*

------
https://chatgpt.com/codex/tasks/task_e_686e9f3df6fc83259a006915dadab402